### PR TITLE
Kubespray new groups names and pause between upgrades

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,6 @@ bin_dir: /usr/local/bin
 drain_grace_period: 300
 # The length of time to wait before giving up, zero means infinite.
 drain_timeout: 360s
+# Period of time in seconds given before draining the next node
+wait_after_uncordon_enabled: false
+wait_after_uncordon_period_seconds: 60

--- a/examples/hosts.example
+++ b/examples/hosts.example
@@ -9,30 +9,30 @@ ansible_python_interpreter=/usr/bin/python3
 # ## different ip than the default iface
 # ## We should set etcd_member_name for etcd cluster. The node that is not a etcd member do not need to set the value, or can set the empty string value.
 [all]
-k8s-master-0 ansible_host=192.168.0.1 etcd_member_name=etcd1
+k8s-control-plane-0 ansible_host=192.168.0.1 etcd_member_name=etcd1
 k8s-node-0 ansible_host=192.168.0.2 etcd_member_name=etcd2
 k8s-node-1 ansible_host=192.168.0.3 etcd_member_name=etcd3
 
 # ## configure a bastion host if your nodes are not directly reachable
 # bastion ansible_host=x.x.x.x ansible_user=some_user
 
-[kube-master]
-k8s-master-0
+[kube_control_plane]
+k8s-control-plane-0
 
 [etcd]
-k8s-master-0
+k8s-control-plane-0
 k8s-node-0
 k8s-node-1
 
-[kube-node]
+[kube_node]
 k8s-node-0
 k8s-node-1
 
 
 [k8s-cluster:children]
-kube-master
-kube-node
+kube_control_plane
+kube_node
 
 [kubespray:children]
-kube-master
-kube-node
+kube_control_plane
+kube_node

--- a/examples/playbook.yml
+++ b/examples/playbook.yml
@@ -1,7 +1,7 @@
 ---
 - hosts:
-    - kube-master
-    - kube-node
+    - kube_control_plane
+    - kube_node
   become: true
   become_method: sudo
   serial: 1

--- a/tasks/drain.yml
+++ b/tasks/drain.yml
@@ -3,7 +3,7 @@
   command: >-
     {{ bin_dir }}/kubectl cordon
     {{ kube_override_hostname|default(inventory_hostname) }}
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
   changed_when: false
 
 - name: Wait for node to cordon
@@ -14,7 +14,7 @@
   register: wait_for_cordon
   retries: 10
   delay: 10
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
   changed_when: false
   until: (wait_for_cordon['stdout'] | from_json).spec.unschedulable
 
@@ -26,5 +26,5 @@
     --grace-period {{ drain_grace_period }}
     --timeout {{ drain_timeout }}
     --delete-local-data {{ kube_override_hostname|default(inventory_hostname) }}
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
   changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
       include_tasks: drain.yml
 
     - name: Upgrade the Operating System
-      include_tasks: "{{ ansible_distribution }}.yml"
+      include_tasks: "{{ ansible_distribution | lower }}.yml"
 
     - name: Uncordon node
       include_tasks: uncordon.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     {{ kube_override_hostname|default(inventory_hostname) }}
     -o json
   register: kubectl_get_node
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
   failed_when: false
   changed_when: false
 

--- a/tasks/uncordon.yml
+++ b/tasks/uncordon.yml
@@ -17,3 +17,9 @@
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
   changed_when: false
   until: not (kubectl_get_node['stdout'] | from_json).spec.unschedulable is defined
+
+- name: Wait before uncordoning node
+  pause:
+    seconds: "{{ wait_after_uncordon_period_seconds }}"
+  when:
+  - wait_after_uncordon_enabled

--- a/tasks/uncordon.yml
+++ b/tasks/uncordon.yml
@@ -3,7 +3,7 @@
   command: >-
     {{ bin_dir }}/kubectl uncordon
     {{ kube_override_hostname|default(inventory_hostname) }}
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
   changed_when: false
 
 - name: Wait for node to uncordon
@@ -14,6 +14,6 @@
   register: wait_for_uncordon
   retries: 10
   delay: 10
-  delegate_to: "{{ groups['kube-master'][0] }}"
+  delegate_to: "{{ groups['kube_control_plane'][0] }}"
   changed_when: false
   until: not (kubectl_get_node['stdout'] | from_json).spec.unschedulable is defined


### PR DESCRIPTION
Hi,

Kubespray changed the **master** group name to **control-plane** in this PR (https://github.com/kubernetes-sigs/kubespray/pull/7183) and **kube-node** to **kube_node** in this PR (https://github.com/kubernetes-sigs/kubespray/pull/7552)

For large clusters, it is better to wait pods rescheduling, like the Kubespray **upgrade_node_post_upgrade_pause_seconds** variable (https://github.com/kubernetes-sigs/kubespray/blob/0f73d87509c780e76ed0463560f4ee271a9d5e44/roles/upgrade/post-upgrade/defaults/main.yml#L5),
To solve the issue, i added two variables (**wait_after_uncordon_enabled** and **wait_after_uncordon_period_seconds**).